### PR TITLE
feat(holidays): add Swedish holiday data from Svenska Dagar API

### DIFF
--- a/backfill-holiday-data.py
+++ b/backfill-holiday-data.py
@@ -1,0 +1,98 @@
+"""
+Backfill Swedish holiday data from Svenska Dagar API into Hopsworks feature store.
+
+Svenska Dagar API: https://sholiday.faboul.se
+- Free, no API key required
+- Provides Swedish holidays, red days, work-free days, days before holidays
+"""
+
+import hopsworks
+import pandas as pd
+from datetime import datetime
+import os
+from dotenv import load_dotenv
+
+from util import fetch_swedish_holidays, clean_column_names
+
+load_dotenv()
+
+
+def create_holiday_feature_group(fs):
+    """Create or get the holiday feature group in Hopsworks."""
+
+    holiday_fg = fs.get_or_create_feature_group(
+        name="swedish_holidays_fg",
+        version=1,
+        primary_key=["date"],
+        event_time="date",
+        online_enabled=False,
+        description="Swedish holidays and special days from Svenska Dagar API"
+    )
+
+    return holiday_fg
+
+
+def ingest_holiday_data(years: list, project):
+    """
+    Ingest holiday data for specified years into Hopsworks.
+
+    Args:
+        years: List of years to fetch (e.g., [2025, 2026])
+        project: Hopsworks project
+    """
+    fs = project.get_feature_store()
+    holiday_fg = create_holiday_feature_group(fs)
+
+    all_data = []
+
+    for year in years:
+        print(f"Fetching holiday data for {year}...")
+        df = fetch_swedish_holidays(year)
+
+        if df.empty:
+            print(f"  No data for {year}")
+            continue
+
+        print(f"  Fetched {len(df)} days")
+        all_data.append(df)
+
+    if not all_data:
+        print("No holiday data to ingest")
+        return
+
+    combined_df = pd.concat(all_data, ignore_index=True)
+
+    # Ensure proper types
+    combined_df["week"] = combined_df["week"].astype("Int64")
+    combined_df["day_of_week"] = combined_df["day_of_week"].astype("Int64")
+    combined_df["is_work_free"] = combined_df["is_work_free"].astype(bool)
+    combined_df["is_red_day"] = combined_df["is_red_day"].astype(bool)
+    combined_df["is_day_before_holiday"] = combined_df["is_day_before_holiday"].astype(bool)
+
+    # Make date timezone-aware for Hopsworks
+    combined_df["date"] = pd.to_datetime(combined_df["date"]).dt.tz_localize("Europe/Stockholm").dt.tz_convert("UTC")
+
+    print(f"\nIngesting {len(combined_df)} holiday records to Hopsworks...")
+    holiday_fg.insert(clean_column_names(combined_df), write_options={"wait_for_job": False})
+    print("Holiday data ingestion complete!")
+
+
+def main():
+    """Backfill holiday data for relevant years."""
+
+    project = hopsworks.login(
+        project=os.environ["HOPSWORKS_PROJECT"],
+        api_key_value=os.environ["HOPSWORKS_API_KEY"]
+    )
+
+    # Fetch 2025 and 2026 to cover our data range plus future predictions
+    years = [2025, 2026]
+
+    print(f"\nBackfilling Swedish holiday data for years: {years}")
+    print("=" * 60)
+
+    ingest_holiday_data(years, project)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipelines/daily-feature-pipeline.py
+++ b/pipelines/daily-feature-pipeline.py
@@ -33,7 +33,7 @@ HOPSWORKS_API_KEY = os.environ.get("HOPSWORKS_API_KEY")
 def fetch_koda_rt_data(date_str: str, hour: int) -> bytes:
     """Fetch GTFS-RT vehicle positions from KODA API for a specific date and hour."""
     url = f"{KODA_RT_API_BASE_URL}?date={date_str}&hour={hour}&key={KODA_KEY}"
-    
+
     try:
         response = requests.get(url, stream=True, timeout=60)
         if response.status_code == 200 and response.content:
@@ -49,7 +49,7 @@ def parse_vehiclepositions(content: bytes, date: str, hour: int):
     """Parse GTFS-RT VehiclePositions protobuf into list of dict rows."""
     if not content:
         return []
-    
+
     rows = []
     try:
         feed = gtfs_realtime_pb2.FeedMessage()
@@ -58,7 +58,7 @@ def parse_vehiclepositions(content: bytes, date: str, hour: int):
         for entity in feed.entity:
             if not entity.HasField("vehicle"):
                 continue
-            
+
             v = entity.vehicle
             trip = getattr(v, 'trip', None)
             pos = getattr(v, 'position', None)
@@ -85,17 +85,17 @@ def parse_vehiclepositions(content: bytes, date: str, hour: int):
             rows.append(row)
     except Exception as e:
         print(f"  Error parsing protobuf: {e}")
-    
+
     return rows
 
 def fetch_koda_static_data(date_str: str, tmp_dir: str) -> str:
     """Download GTFS static ZIP file from KODA API."""
     url = f"{KODA_STATIC_API_BASE_URL}?date={date_str}&key={KODA_KEY}"
     zip_path = os.path.join(tmp_dir, f"gtfs_static_{date_str.replace('-', '_')}.zip")
-    
+
     if os.path.exists(zip_path):
         return zip_path
-    
+
     try:
         response = requests.get(url, stream=True, timeout=60)
         if response.status_code == 200 and "application/zip" in response.headers.get("Content-Type", ""):
@@ -114,10 +114,10 @@ def get_aggregated_temporal_trip_features(rt_df):
     """Aggregate real-time vehicle data into 1-minute windows."""
     if rt_df.empty:
         return pd.DataFrame()
-    
-    rt_df = rt_df.sort_values(["timestamp", "trip_id", "vehicle_id"])  
+
+    rt_df = rt_df.sort_values(["timestamp", "trip_id", "vehicle_id"])
     rt_df['window_start'] = rt_df['timestamp'].dt.floor('1min')
-    
+
     vehicle_trip_1min_df = (
         rt_df
         .groupby(["trip_id", "window_start"], as_index=False)
@@ -138,7 +138,7 @@ def get_aggregated_temporal_trip_features(rt_df):
             occupancy_mode=("occupancy_status", lambda x: x.mode().iloc[0] if not x.mode().empty else None)
         )
     )
-    
+
     vehicle_trip_1min_df["date"] = vehicle_trip_1min_df["window_start"].dt.date
     vehicle_trip_1min_df["hour"] = vehicle_trip_1min_df["window_start"].dt.hour
     vehicle_trip_1min_df["day_of_week"] = vehicle_trip_1min_df["window_start"].dt.weekday
@@ -184,7 +184,7 @@ def build_situation_query(day_start: str, day_end: str) -> str:
 def fetch_trafikverket_situations(day_start: str, day_end: str) -> ET.Element:
     """Fetch traffic situations from Trafikverket API."""
     xml_query = build_situation_query(day_start, day_end)
-    
+
     try:
         response = requests.post(
             TRAFIKVERKET_API_URL,
@@ -192,11 +192,11 @@ def fetch_trafikverket_situations(day_start: str, day_end: str) -> ET.Element:
             headers={"Content-Type": "application/xml"},
             timeout=60
         )
-        
+
         if response.status_code != 200:
             print(f"  API Error {response.status_code}: {response.text[:200]}")
             return None
-        
+
         return ET.fromstring(response.content)
     except Exception as e:
         print(f"  Error fetching Trafikverket data: {e}")
@@ -206,15 +206,15 @@ def extract_geometry_wkt(geometry_el):
     """Extract WKT geometry from Geometry element."""
     if geometry_el is None:
         return None
-    
+
     wgs84_point = geometry_el.find("Point/WGS84")
     if wgs84_point is not None:
         return wgs84_point.text
-    
+
     wgs84_line = geometry_el.find("Line/WGS84")
     if wgs84_line is not None:
         return wgs84_line.text
-    
+
     wgs84_simple = geometry_el.find("WGS84")
     return wgs84_simple.text if wgs84_simple is not None else None
 
@@ -244,7 +244,7 @@ def extract_deviation_info(dev):
             "severity_text": None, "location_description": None, "valid_until_further_notice": False,
             "geometry_wkt": None, "lat": None, "lon": None, "deviation_id": None,
         }
-    
+
     road_number = dev.findtext("RoadNumber")
     road_number_numeric = dev.findtext("RoadNumberNumeric")
     start_time = dev.findtext("StartTime")
@@ -257,11 +257,11 @@ def extract_deviation_info(dev):
     message_type = dev.findtext("MessageType")
     severity_code = dev.findtext("SeverityCode")
     severity_text = dev.findtext("SeverityText")
-    
+
     geometry_el = dev.find("Geometry")
     geometry_wkt = extract_geometry_wkt(geometry_el)
     lat, lon = parse_wkt_centroid(geometry_wkt)
-    
+
     return {
         "road_number": road_number, "road_number_numeric": road_number_numeric, "start_time": start_time,
         "end_time": end_time, "header": header, "message_code": message_code, "message_type": message_type,
@@ -274,13 +274,13 @@ def parse_situations(root: ET.Element) -> pd.DataFrame:
     """Parse XML situations into DataFrame."""
     if root is None:
         return pd.DataFrame()
-    
+
     rows = []
     for situation in root.findall(".//Situation"):
         situation_id = situation.findtext("Id")
         deleted = situation.findtext("Deleted") == "true"
         deviations = situation.findall("Deviation")
-        
+
         if not deviations:
             deviations = [None]
 
@@ -309,19 +309,19 @@ def main():
         api_key_value=HOPSWORKS_API_KEY
     )
     fs = project.get_feature_store()
-    
+
     # Calculate yesterday's date
     yesterday = datetime.now() - timedelta(days=1)
     yesterday_str = yesterday.strftime("%Y-%m-%d")
     yesterday_ts = pd.Timestamp(yesterday.date(), tz='UTC')
-    
+
     print(f"\n{'='*70}")
     print(f"Running daily feature pipeline for {yesterday.date()}")
     print(f"{'='*70}\n")
-    
+
     tmp_dir = tempfile.mkdtemp()
     rt_rows_all = []
-    
+
     try:
         # Fetch KODA RT vehicle data for all 24 hours
         print(f"Fetching KODA real-time vehicle positions...")
@@ -331,58 +331,58 @@ def main():
             if content:
                 rows = parse_vehiclepositions(content, yesterday_str, hour)
                 rt_rows_all.extend(rows)
-        
+
         if not rt_rows_all:
             print("  No RT data fetched. Exiting.")
             return
-        
+
         rt_df = pd.DataFrame(rt_rows_all)
         rt_df["timestamp"] = pd.to_datetime(rt_df["timestamp"], utc=True)
         rt_df = rt_df[rt_df['trip_id'].notna() & rt_df['vehicle_id'].notna()]
-        
+
         # Aggregate to 1-minute windows
         trip_agg_df = get_aggregated_temporal_trip_features(rt_df)
         if trip_agg_df.empty:
             print("   No aggregated data after processing. Exiting.")
             return
-        
+
         print(f"    Fetched and aggregated {len(trip_agg_df)} trip windows")
-        
+
         # Ingest to vehicle_trip_agg_fg
         print(f"  Ingesting to vehicle_trip_agg_fg...")
         vehicle_fg = fs.get_feature_group(name="vehicle_trip_agg_fg", version=2)
         vehicle_fg.insert(clean_column_names(trip_agg_df), write_options={"wait_for_job": False})
         print(f"  Ingested {len(trip_agg_df)} records to vehicle_trip_agg_fg")
-        
+
         # Fetch Trafikverket traffic events
         print(f"\nFetching Trafikverket traffic events...")
         day_start = yesterday_str + "T00:00:00"
         day_end = yesterday_str + "T23:59:59"
-        
+
         root = fetch_trafikverket_situations(day_start, day_end)
         traffic_df = parse_situations(root)
-        
+
         if not traffic_df.empty:
             # Convert timestamps to UTC-aware datetime
             traffic_df["start_time"] = pd.to_datetime(traffic_df["start_time"], utc=True)
             traffic_df["end_time"] = pd.to_datetime(traffic_df["end_time"], errors="coerce", utc=True)
-            
+
             # Remove rows with null start_time
             traffic_df = traffic_df.dropna(subset=["start_time"])
-            
+
             # Fill missing end_time with start_time + 1 day
             missing_end = traffic_df["end_time"].isna()
             traffic_df.loc[missing_end, "end_time"] = traffic_df.loc[missing_end, "start_time"] + timedelta(days=1)
-            
+
             # Type conversions
             traffic_df["latitude"] = pd.to_numeric(traffic_df["latitude"], errors="coerce")
             traffic_df["longitude"] = pd.to_numeric(traffic_df["longitude"], errors="coerce")
             traffic_df["road_number_numeric"] = pd.to_numeric(traffic_df["road_number_numeric"], errors="coerce")
             traffic_df["valid_until_further_notice"] = traffic_df["valid_until_further_notice"].astype(bool)
             traffic_df["deleted"] = traffic_df["deleted"].astype(bool)
-            
+
             print(f"  Fetched {len(traffic_df)} traffic events")
-            
+
             # Ingest to trafikverket_traffic_event_fg
             print(f"  Ingesting to trafikverket_traffic_event_fg...")
             traffic_fg = fs.get_feature_group(name="trafikverket_traffic_event_fg", version=2)
@@ -391,7 +391,7 @@ def main():
         else:
             print(f"  No traffic events found for {yesterday.date()}")
             traffic_df = pd.DataFrame()
-        
+
         # Fetch weather data for yesterday
         print(f"\nFetching weather data...")
         try:
@@ -420,9 +420,26 @@ def main():
             print(f"  Warning: Could not fetch weather data: {e}")
             weather_df = pd.DataFrame()
 
-        # Create enriched features combining trip + traffic + weather
+        # Fetch holiday data for yesterday
+        print(f"\nFetching holiday data...")
+        try:
+            holiday_features = get_holiday_features_for_date(yesterday)
+            print(f"  Holiday features: work_free={holiday_features['is_work_free']}, "
+                  f"red_day={holiday_features['is_red_day']}, "
+                  f"holiday={holiday_features['holiday_name']}")
+        except Exception as e:
+            print(f"  Warning: Could not fetch holiday data: {e}")
+            holiday_features = {
+                "is_work_free": False,
+                "is_red_day": False,
+                "is_day_before_holiday": False,
+                "is_holiday": False,
+                "holiday_name": None,
+            }
+
+        # Create enriched features combining trip + traffic + weather + holidays
         print(f"\nCreating enriched features...")
-        
+
         if traffic_df.empty:
             enriched_df = trip_agg_df.copy()
             enriched_df["has_nearby_event"] = 0
@@ -435,14 +452,14 @@ def main():
             for idx, trip_row in trip_agg_df.iterrows():
                 window_start = trip_row["window_start"]
                 trip_lat, trip_lon = trip_row["lat_mean"], trip_row["lon_mean"]
-                
+
                 # Find active traffic events within 500m
                 if pd.notna(trip_lat) and pd.notna(trip_lon):
                     nearby = traffic_df[
                         (traffic_df["start_time"] <= window_start) &
                         (traffic_df["end_time"] >= window_start)
                     ].copy()
-                    
+
                     nearby["distance_m"] = nearby.apply(
                         lambda r: distance_m(trip_lat, trip_lon, r["latitude"], r["longitude"]),
                         axis=1
@@ -450,7 +467,7 @@ def main():
                     nearby = nearby[nearby["distance_m"] <= 500]
                 else:
                     nearby = pd.DataFrame()
-                
+
                 if nearby.empty:
                     enriched_data.append({
                         "has_nearby_event": 0,
@@ -463,14 +480,14 @@ def main():
                     max_severity = int(severity_codes.max()) if len(severity_codes) > 0 else None
                     affected_roads = nearby["affected_road"].dropna().unique()
                     roads_str = ",".join(str(r) for r in affected_roads) if len(affected_roads) > 0 else None
-                    
+
                     enriched_data.append({
                         "has_nearby_event": int(len(nearby) > 0),
                         "num_nearby_traffic_events": len(nearby),
                         "nearby_event_severity": max_severity,
                         "affected_roads": roads_str,
                     })
-            
+
             enriched_features = pd.DataFrame(enriched_data)
             enriched_df = pd.concat([trip_agg_df.reset_index(drop=True), enriched_features], axis=1)
 
@@ -493,6 +510,12 @@ def main():
             enriched_df["wind_speed_10m"] = None
             enriched_df["weather_code"] = None
 
+        # Add holiday features (same for all rows since it's a single day)
+        enriched_df["is_work_free"] = holiday_features["is_work_free"]
+        enriched_df["is_red_day"] = holiday_features["is_red_day"]
+        enriched_df["is_day_before_holiday"] = holiday_features["is_day_before_holiday"]
+        enriched_df["is_holiday"] = holiday_features["is_holiday"]
+
         # Ingest to combined feature group
         print(f"  Creating/updating trip_occupancy_features_daily...")
         enriched_fg = fs.get_or_create_feature_group(
@@ -501,23 +524,23 @@ def main():
             primary_key=["trip_id", "window_start"],
             event_time="window_start",
             online_enabled=False,
-            description="Daily enriched trip features with vehicle metrics, nearby traffic events, and weather"
+            description="Daily enriched trip features with vehicle metrics, traffic events, weather, and holidays"
         )
-        
+
         enriched_df.columns = (
             enriched_df.columns
             .str.strip()
             .str.lower()
             .str.replace(" ", "_")
         )
-        
+
         enriched_fg.insert(clean_column_names(enriched_df), write_options={"wait_for_job": False})
         print(f"  Ingested {len(enriched_df)} enriched records to trip_occupancy_features_daily")
-        
+
         print(f"\n{'='*70}")
         print(f"Daily feature pipeline completed successfully for {yesterday.date()}")
         print(f"{'='*70}\n")
-        
+
     finally:
         # Cleanup
         import shutil


### PR DESCRIPTION
 ## Summary
- Add backfill script for Swedish holiday data (`backfill-holiday-data.py`)
- Add holiday utility functions to `util.py`
- Update daily pipeline to fetch and include holiday features

## Holiday features added
- `is_work_free` - Whether the day is work-free
- `is_red_day` - Whether it's a "red day" (public holiday)
- `is_day_before_holiday` - Day before a work-free holiday
- `is_holiday` - Whether there's a named holiday

## Data source
Svenska Dagar API (free, no API key required)
- Endpoint: sholiday.faboul.se/dagar/v2.1

Closes #10