### PR TITLE
fix(ui): read monitoring data from monitor_fg v2

### DIFF
--- a/ui/pages/Monitoring.py
+++ b/ui/pages/Monitoring.py
@@ -64,7 +64,7 @@ def fetch_monitoring_data():
         project = hopsworks.login()
         fs = project.get_feature_store()
 
-        monitor_fg = fs.get_feature_group("monitor_fg", version=1)
+        monitor_fg = fs.get_feature_group("monitor_fg", version=2)
         df = monitor_fg.read()
 
         if df is not None and not df.empty:


### PR DESCRIPTION
The inference pipeline uploads to monitor_fg v2 (due to schema change
with trip_id as string), but the UI was still reading from v1.